### PR TITLE
use pretty-stream and multi-stdout

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -3,7 +3,10 @@
 var through = require('through2');
 var tcpSpy = require('./');
 var chalk = require('chalk')
-var argv = require('minimist')(process.argv.slice(2));
+var argv = require('minimist')(process.argv.slice(2), {boolean:true});
+var pretty = require('pretty-stream');
+var mstdout = require('multi-stdout');
+var os = require('os');
  
 var hexStream = function() {
   return through(function(chunk, enc, callback) {
@@ -11,55 +14,19 @@ var hexStream = function() {
       var str = x.toString(16);
       return '00'.slice(str.toString().length) + str;
     });
-    callback(null, arr.join(' '));
+    callback(null, arr.join(' ')+' ');
   });
 };
- 
-var prefixer = function(prefix) {
-  var offset = 0;
-  return function(data) {
-    var result = prefix+'  '+chalk.grey('00000000'.slice(offset.toString().length)+offset)+'  ';
-    offset += data.length;
-    return result;
-  }
-}
- 
-var formatStream = function(prefix) {
-  var width = 0;
-  var max = process.stdout.columns-25;
- 
-  return through(function(chunk, enc, callback) {
-    var lines = [];
-    var prev = 0;
- 
-    for (var i = 0; i < chunk.length; i++) {
-      width += chunk[i] === 9 ? 8 : 1;
-      if (chunk[i] === 10 || width >= max) {
-        lines.push(chunk.slice(prev, i+1));
-        prev = i+1;
-        width = 0;
-      }
-    }
- 
-    var last = chunk.slice(prev);
-    if (last.length) lines.push(last);
- 
-    var self = this;
-    lines.forEach(function(chunk) {
-      self.push(prefix(chunk));
-      self.push(chunk);
-      if (chunk[chunk.length-1] !== 10) self.push(new Buffer([10]));
-    });
 
-    width = 0;
- 
-    callback();
-  })
-}
- 
-var newlineStream = function() {
-  return through(function(chunk, enc, callback) {
-    callback(null, '\n' + chunk);
+var formatStream = function(prefix) {
+  return pretty({
+    prefix: function(data) {
+      return prefix+'  '+chalk.grey(data);
+    },
+    binary: function(data) {
+      return chalk.bgBlue(data);
+    },
+    truncate: argv.t || argv.truncate
   });
 };
  
@@ -70,7 +37,8 @@ if (argv._.length !== 2) {
   console.log('');
   console.log('Options:');
   console.log('');
-  console.log('  --hex -x Hexadecimal output');
+  console.log('  --hex -x       Force hexadecimal output');
+  console.log('  --truncate -t  Truncate binary output');
   console.log('');
   process.exit(1);
 }
@@ -87,16 +55,22 @@ if (typeof forwardPort === 'string' && forwardPort.indexOf(':') !== -1) {
 var connId = 0;
 var spy = tcpSpy({port: port, forwardPort: forwardPort, forwardHost: host});
 var transform = argv.x || argv.hex ? hexStream : through
+
 spy.on('connection', function(client, server) {
   var id = ++connId;
   id = '00'.slice(id.toString().length) + id;
-  console.log(id + '  ' + chalk.green('***') + chalk.yellow('  Connection established'));
-  client.pipe(transform()).pipe(formatStream(prefixer(id + '  ' + chalk.bold(chalk.magenta('-->'))))).pipe(process.stdout);
-  server.pipe(transform()).pipe(formatStream(prefixer(id + '  ' + chalk.bold(chalk.cyan('<--'))))).pipe(process.stdout);
 
-  client.on('end', function() {
-    console.log(id + '  ' + chalk.green('***') + chalk.red('  Connection finished'));
+  var padding = through(function(data, enc, cb) {
+    cb(null, data);
+  }, function(cb) {
+    this.push(id + '  ' + chalk.green('***') + chalk.red('  Connection finished'));
+    cb();
   });
+
+  padding.push(id + '  ' + chalk.green('***') + chalk.yellow('  Connection established')+os.EOL);
+
+  client.pipe(transform()).pipe(formatStream(id + '  ' + chalk.bold(chalk.magenta('-->')))).pipe(padding).pipe(mstdout());
+  server.pipe(transform()).pipe(formatStream(id + '  ' + chalk.bold(chalk.cyan('<--')))).pipe(mstdout());
 });
 
 process.stdout.setMaxListeners(0);

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "TCP Proxy server for debugging.",
   "main": "index.js",
   "dependencies": {
+    "chalk": "^0.4.0",
     "minimist": "~0.2.0",
-    "through2": "~0.5.1",
-    "chalk": "^0.4.0"
+    "multi-stdout": "^1.0.0",
+    "pretty-stream": "^1.2.1",
+    "through2": "~0.5.1"
   },
   "devDependencies": {
     "tape": "^2.13.3"


### PR DESCRIPTION
output is now way more epic

try the following example

``` js
// server.js
var net = require('net')

var server = net.createServer(function(sock) {
  sock.pipe(sock)
})

server.listen(5000)
```

first boot up tcp spy

```
tcp-spy 4000 5000
```

then the echo server

```
node server.js
```

then run

```
# use killall node to kill this since it uses raw mode
node -e 'process.stdin.setRawMode(true); process.stdin.pipe(require("net").connect(4000)).pipe(process.stdout)'
```

notice how multiline updates work now!
